### PR TITLE
Enable multiple inheritance of abstract Models that contains ForeinKeys

### DIFF
--- a/src/django_xworkflows/models.py
+++ b/src/django_xworkflows/models.py
@@ -406,7 +406,7 @@ class GenericTransitionLog(BaseTransitionLog):
 
     content_type = models.ForeignKey(ct_models.ContentType,
                                      verbose_name=_(u"Content type"),
-                                     related_name="workflow_object",
+                                     related_name='%(app_label)s_%(class)s_workflow_object',
                                      blank=True, null=True)
     content_id = models.PositiveIntegerField(_(u"Content id"),
         blank=True, null=True, db_index=True)


### PR DESCRIPTION
Hi,

I 'm trying to use my own TransitionLog Model for some workflows and in the same time, I would like to use django_xworkflows.xworkflow_log as a default TransitionLog Model for all workflows.

But Django doesn't allow me to do that because of GenericTransitionLog.content_type field.

The related_name is hardcoded as 'workflow_object', so once it has been registered for default TransitionLog, my own Model can not reuse it.

According to django documentation https://docs.djangoproject.com/en/dev/topics/db/models/#be-careful-with-related-name , we can compute this related_name dynamically.

I quickly wrote a patch and run the test suite without detecting regression.

This PR miss also the south migration, can you explain me how can I generate it ?

Thanks,
Nicolas
