### PR TITLE
Django 1.7 compatibility

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -26,6 +26,15 @@ if not settings.configured:
         ]
     )
 
+
+try:
+    # Needed by the new Django1.7 app-loading feature.
+    from django import setup
+    setup()
+except ImportError:
+    pass
+
+
 from django.test import simple
 
 


### PR DESCRIPTION
The new app-loading feature needs that external scripts (like the test runner)
call `django.setup()` before doing anything else.

The new migrations feature needs a way to serialize (deconstruct) fields. Also,
it needs a way to deconstruct models.

The hack on the WorkflowEnabled class is needed, it seems, because of
http://stackoverflow.com/questions/11209521/base-metaclass-overriding-new-generates-classes-with-a-wrong-module.
It was trying to serialize it (in the migrations) as
`django.db.base.WorkflowEnabled`.
