### PR TITLE
moodels: fix base.WorkflowMeta call for Django migrations

### DIFF
--- a/django_xworkflows/models.py
+++ b/django_xworkflows/models.py
@@ -317,7 +317,9 @@ class _SerializedWorkflow(object):
         # Create a new django_xworkflows.models.Workflow subclass,
         # using the provided fields.
         workflow_class = base.WorkflowMeta(
-            self._name,
+            # When constructing from django.db.migrations, we might get a unicode instead of a str for the name; 
+            # this breaks calls to super()
+            str(self._name),
             (Workflow,),
             {
                 'states': [(st, st) for st in states],


### PR DESCRIPTION
Don't know if I have to register a line in the changelog or if you do it when releasing.

This aim to fix an auto-generated migration from Django : 
``` 
File "/home/qbey/dev/leasetaylor_venv/local/lib/python2.7/site-packages/subzero/core/telephony/migrations/0001_initial.py", line 135, in Migration
    ('state', django_xworkflows.models.StateField(max_length=16, workflow=django_xworkflows.models._SerializedWorkflow(states=['not_initiated', 'unattended', 'pending', 'bridge', 'cancel'], initial_state='not_initiated', name='CallTransferWorkflow'))),
  File "/home/qbey/dev/leasetaylor_venv/local/lib/python2.7/site-packages/django_xworkflows/models.py", line 326, in __init__
    'initial_state': initial_state,
  File "/home/qbey/dev/leasetaylor_venv/local/lib/python2.7/site-packages/xworkflows/base.py", line 811, in __new__
    new_class = super(WorkflowMeta, mcs).__new__(mcs, name, bases, attrs)
TypeError: type() argument 1 must be string, not unicode
```