### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Django-XWorkflows
     :target: http://travis-ci.org/rbarrois/django_xworkflows/
 
 .. image:: https://img.shields.io/pypi/v/django_xworkflows.svg
-    :target: http://django-xworkflows.readthedocs.org/en/latest/changelog.html
+    :target: https://django-xworkflows.readthedocs.io/en/latest/changelog.html
     :alt: Latest Version
 
 .. image:: https://img.shields.io/pypi/pyversions/django_xworkflows.svg
@@ -71,5 +71,5 @@ Links
 
 * Package on PyPI: http://pypi.python.org/pypi/django-xworkflows
 * Repository and issues on GitHub: http://github.com/rbarrois/django_xworkflows
-* Doc on http://readthedocs.org/docs/django-xworkflows/
+* Doc on https://django-xworkflows.readthedocs.io/
 * XWorkflows on GitHub: http://github.com/rbarrois/xworkflows

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,7 +98,7 @@ pygments_style = 'sphinx'
 #modindex_common_prefix = []
 
 intersphinx_mapping = {
-    'xworkflows': ('http://readthedocs.org/docs/xworkflows/en/latest/', None),
+    'xworkflows': ('https://xworkflows.readthedocs.io/en/latest/', None),
     'django': ('http://docs.djangoproject.com/en/dev/',
                'http://docs.djangoproject.com/en/dev/_objects/'),
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,9 +86,9 @@ Resources
 
 * Package on PyPI: http://pypi.python.org/pypi/django-xworkflows
 * Repository and issues on GitHub: http://github.com/rbarrois/django_xworkflows
-* Doc on http://readthedocs.org/docs/django-xworkflows/
+* Doc on https://django-xworkflows.readthedocs.io/
 * XWorkflows on GitHub: http://github.com/rbarrois/xworkflows
-* XWorkflows doc on http://readthedocs.org/docs/xworkflows/
+* XWorkflows doc on https://xworkflows.readthedocs.io/
 
 Indices and tables
 ==================


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.