### PR TITLE
Dbaty/django 10 compat and related fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+  - "3.6"
 env:
   - DJANGO_VERSION=1.7
   - DJANGO_VERSION=1.8
@@ -10,6 +11,9 @@ env:
 matrix:
   exclude:
     - python: 3.5
+      env: DJANGO_VERSION=1.7
+
+    - python: 3.6
       env: DJANGO_VERSION=1.7
 
 script: "python setup.py test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - DJANGO_VERSION=1.7
   - DJANGO_VERSION=1.8
   - DJANGO_VERSION=1.9
+  - DJANGO_VERSION=1.10
 matrix:
   exclude:
     - python: 3.5

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ DOC_DIR=docs
 COVERAGE = python $(shell which coverage)
 
 # Dependencies
-DJANGO ?= 1.9
-NEXT_DJANGO = $(shell python -c "v='$(DJANGO)'; parts=v.split('.'); parts[-1]=str(int(parts[-1])+1); print('.'.join(parts))")
+DJANGO_VERSION ?= 1.9
+NEXT_DJANGO_VERSION = $(shell python -c "v='$(DJANGO_VERSION)'; parts=v.split('.'); parts[-1]=str(int(parts[-1])+1); print('.'.join(parts))")
 
-REQ_FILE = auto_dev_requirements_django$(DJANGO).txt
+REQ_FILE = auto_dev_requirements_django$(DJANGO_VERSION).txt
 
 all: default
 
@@ -24,7 +24,7 @@ install-deps: $(REQ_FILE)
 
 auto_dev_requirements_%.txt: dev_requirements_%.txt dev_requirements.txt requirements.txt
 	grep --no-filename "^[^#-]" $^ | grep -v "^Django" > $@
-	echo "Django>=$(DJANGO),<$(NEXT_DJANGO)" >> $@
+	echo "Django>=$(DJANGO_VERSION),<$(NEXT_DJANGO_VERSION)" >> $@
 
 clean:
 	find . -type f -name '*.pyc' -delete

--- a/dev/settings.py
+++ b/dev/settings.py
@@ -84,6 +84,26 @@ TEMPLATE_LOADERS = (
 #     'django.template.loaders.eggs.Loader',
 )
 
+# For Django >= 1.10
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/dev_requirements_django1.10.txt
+++ b/dev_requirements_django1.10.txt
@@ -1,0 +1,3 @@
+-r dev_requirements.txt
+
+# Nothing additional.

--- a/django_xworkflows/models.py
+++ b/django_xworkflows/models.py
@@ -31,7 +31,7 @@ transition = base.transition
 class StateSelect(widgets.Select):
     """Custom 'select' widget to handle state retrieval."""
 
-    def render(self, name, value, attrs=None, choices=()):
+    def render(self, name, value, attrs=None, *args, **kwargs):
         """Handle a few expected values for rendering the current choice.
 
         Extracts the state name from StateWrapper and State object.
@@ -42,7 +42,7 @@ class StateSelect(widgets.Select):
             state_name = value.name
         else:
             state_name = str(value)
-        return super(StateSelect, self).render(name, state_name, attrs, choices)
+        return super(StateSelect, self).render(name, state_name, attrs, *args, **kwargs)
 
 
 class StateFieldProperty(object):
@@ -584,4 +584,3 @@ class GenericLastTransitionLog(BaseLastTransitionLog):
         unique_fields['content_id'] = content_id
 
         return super(GenericLastTransitionLog, cls)._update_or_create(unique_fields, **kwargs)
-

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     test_suite='tests.runner.runtests',
     zip_safe=False,  # Prevent distribution as eggs for South.

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -26,6 +26,24 @@ if not settings.configured:
             'django_xworkflows.xworkflow_log',
         ],
         MIDDLEWARE_CLASSES=[],
+        TEMPLATES = [
+            {
+                'BACKEND': 'django.template.backends.django.DjangoTemplates',
+                'DIRS': [],
+                'APP_DIRS': True,
+                'OPTIONS': {
+                    'context_processors': [
+                        'django.contrib.auth.context_processors.auth',
+                        'django.template.context_processors.debug',
+                        'django.template.context_processors.i18n',
+                        'django.template.context_processors.media',
+                        'django.template.context_processors.static',
+                        'django.template.context_processors.tz',
+                        'django.contrib.messages.context_processors.messages',
+                    ],
+                },
+            },
+        ]
     )
 
 if django.VERSION[:2] >= (1, 7):
@@ -49,4 +67,3 @@ def runtests(*test_args):
 
 if __name__ == '__main__':
     runtests(*sys.argv[1:])
-


### PR DESCRIPTION
- compatibility with Django 1.10 (same fix as in #24, a new test for it, and adapt existing tests);
- document support of Python 3.6 (and add builds to Travis)
- fix requirement installation in Makefile (all Travis builds use the same Django version, currently).