### PR TITLE
adds compatible on_delete on ForeignKey

### DIFF
--- a/django_xworkflows/models.py
+++ b/django_xworkflows/models.py
@@ -476,7 +476,9 @@ class GenericTransitionLog(BaseTransitionLog):
     """
     MODIFIED_OBJECT_FIELD = 'modified_object'
 
-    content_type = models.ForeignKey(ct_models.ContentType, verbose_name=_("Content type"), blank=True, null=True)
+    content_type = models.ForeignKey(
+        ct_models.ContentType, verbose_name=_("Content type"), blank=True, null=True, on_delete=models.CASCADE,
+    )
     content_id = models.PositiveIntegerField(_("Content id"), blank=True, null=True, db_index=True)
     modified_object = ct_fields.GenericForeignKey(ct_field="content_type", fk_field="content_id")
 

--- a/django_xworkflows/xworkflow_log/migrations/0001_initial.py
+++ b/django_xworkflows/xworkflow_log/migrations/0001_initial.py
@@ -26,8 +26,8 @@ class Migration(migrations.Migration):
                 ('to_state', models.CharField(max_length=255, verbose_name='to state', db_index=True)),
                 ('timestamp', models.DateTimeField(default=django.utils.timezone.now, verbose_name='performed at', db_index=True)),
                 ('content_id', models.PositiveIntegerField(db_index=True, null=True, verbose_name='Content id', blank=True)),
-                ('content_type', models.ForeignKey(verbose_name='Content type', blank=True, to='contenttypes.ContentType', null=True)),
-                ('user', models.ForeignKey(verbose_name='author', blank=True, to=XWORKFLOWS_USER_MODEL, null=True)),
+                ('content_type', models.ForeignKey(verbose_name='Content type', blank=True, to='contenttypes.ContentType', null=True, on_delete=models.CASCADE)),
+                ('user', models.ForeignKey(verbose_name='author', blank=True, to=XWORKFLOWS_USER_MODEL, null=True, on_delete=models.CASCADE)),
             ],
             options={
                 'ordering': ('-timestamp', 'transition'),

--- a/django_xworkflows/xworkflow_log/models.py
+++ b/django_xworkflows/xworkflow_log/models.py
@@ -32,4 +32,5 @@ class TransitionLog(models.GenericTransitionLog):
 
     user = django_models.ForeignKey(
         getattr(settings, 'XWORKFLOWS_USER_MODEL', getattr(settings, 'AUTH_USER_MODEL', 'auth.User')),
-        blank=True, null=True, verbose_name=_("author"))
+        blank=True, null=True, on_delete=django_models.CASCADE, verbose_name=_("author"),
+    )


### PR DESCRIPTION
For now django_xworkflows didn't set any on_delete rule.
This commits keeps the current behaviour