### PR TITLE
Add missing on_delete on GenericLastTransitionLog model

### DIFF
--- a/django_xworkflows/models.py
+++ b/django_xworkflows/models.py
@@ -540,7 +540,8 @@ class GenericLastTransitionLog(BaseLastTransitionLog):
 
     content_type = models.ForeignKey(
         ct_models.ContentType, verbose_name=_("Content type"), related_name='last_transition_logs',
-        blank=True, null=True)
+        blank=True, null=True, on_delete=models.CASCADE,
+    )
     content_id = models.PositiveIntegerField(_("Content id"), blank=True, null=True, db_index=True)
     modified_object = ct_fields.GenericForeignKey(ct_field="content_type", fk_field="content_id")
 


### PR DESCRIPTION
There was still a on_delete attribute, missing on GenericLastTransitionLog.

Note: I didn't find any migration for this model.