### PR TITLE
Fix a django 3.0 compatibility issue.

### DIFF
--- a/django_xworkflows/models.py
+++ b/django_xworkflows/models.py
@@ -16,9 +16,19 @@ from django.core import exceptions
 from django.forms import fields
 from django.forms import widgets
 from django.utils.deconstruct import deconstructible
-from django.utils.encoding import force_text, python_2_unicode_compatible
+from django.utils.encoding import force_text
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
+
+try:
+    from django.utils.encoding import python_2_unicode_compatible
+except ImportError:
+    try:
+        from six import python_2_unicode_compatible
+    except ImportError:
+        raise exceptions.ImproperlyConfigured(
+            'Starting from django 3.0, you must provide your own installation '
+            'of the `six` package.')
 
 from xworkflows import base
 


### PR DESCRIPTION
This is my fix for issue #31.

In Django 3.0, some third-party apps aliases were removed. Hence, we had to fix the failing imports.

See https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis