### PR TITLE
docs: Fix simple typo, functionnalities -> functionalities

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 django-xworkflows documentation
 ===============================
 
-django-xworkflows is a django application adding `xworkflows <http://github.com/rbarrois/xworkflows/>`_ functionnalities to
+django-xworkflows is a django application adding `xworkflows <http://github.com/rbarrois/xworkflows/>`_ functionalities to
 django models.
 
 


### PR DESCRIPTION
There is a small typo in docs/index.rst.

Should read `functionalities` rather than `functionnalities`.

